### PR TITLE
Fix Assome spelling error.

### DIFF
--- a/reuben3/language.cpp
+++ b/reuben3/language.cpp
@@ -70,7 +70,7 @@ const MultiLang lang_battle_magic_bolt[] = {
 const MultiLang lang_battle_magic_stun[] = {
 	{LANG_EN, "Stun"},
 	{LANG_DE, "Lähmen"},
-	{LANG_FR, "Assome"},
+	{LANG_FR, "Bloque"},
 };
 
 // main menu stuff


### PR DESCRIPTION
Assome should be spelled Assomme. However, it probably doesn't fit.
Replaces with "Bloque" which is actually what the action is about.